### PR TITLE
Keep APPX Bundle Enhancement

### DIFF
--- a/BedrockLauncher/Handlers/PackageHandler.cs
+++ b/BedrockLauncher/Handlers/PackageHandler.cs
@@ -201,7 +201,7 @@ namespace BedrockLauncher.Handlers
                 SetCancelation(true);
 
                 string dlPath = "Minecraft-" + v.Name + ".Appx";
-                await DownloadPackage(v, dlPath, CancelSource);
+                if (!File.Exists(dlPath)) await DownloadPackage(v, dlPath, CancelSource);
                 await ExtractPackage(v, dlPath, CancelSource);
 
                 v.UpdateFolderSize();
@@ -298,7 +298,7 @@ namespace BedrockLauncher.Handlers
                 fileStream.Close();
                 await File.WriteAllTextAsync(v.IdentificationPath, v.PackageID);
                 File.Delete(Path.Combine(v.GameDirectory, "AppxSignature.p7x"));
-                File.Delete(dlPath);
+                //File.Delete(dlPath);
 
                 Trace.WriteLine("Extracted successfully");
             }

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2024.5.31.2")]
+[assembly: AssemblyVersion("2024.8.14.5")]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
#485 Requested. Launcher will now keep APPX files inside the "app" folder (assuming use of the bootstrapper which uses the startbedrocklauncher.exe file). Will also check if this appx file already exists before downloading again.