### PR TITLE
 Use dedicated folder for .appx bundle storage.

### DIFF
--- a/BedrockLauncher/Handlers/PackageHandler.cs
+++ b/BedrockLauncher/Handlers/PackageHandler.cs
@@ -201,7 +201,7 @@ namespace BedrockLauncher.Handlers
                 SetCancelation(true);
 
                 string exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                string subDirectory = Path.Combine(exeDirectory, "Appx backups");
+                string subDirectory = Path.Combine(exeDirectory, "AppxBackups");
                 string dlPath = Path.Combine(subDirectory, "Minecraft-" + v.Name + ".Appx");
                 if (!File.Exists(Path.Combine(subDirectory, dlPath))) await DownloadPackage(v, dlPath, CancelSource);
                 await ExtractPackage(v, dlPath, CancelSource);
@@ -302,7 +302,7 @@ namespace BedrockLauncher.Handlers
                 File.Delete(Path.Combine(v.GameDirectory, "AppxSignature.p7x"));
                 //File.Delete(dlPath);
                 string exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                string subDirectory = Path.Combine(exeDirectory, "Appx backups");
+                string subDirectory = Path.Combine(exeDirectory, "AppxBackups");
                 if (!Directory.Exists(subDirectory))
                 {
                     Directory.CreateDirectory(subDirectory);

--- a/BedrockLauncher/Handlers/PackageHandler.cs
+++ b/BedrockLauncher/Handlers/PackageHandler.cs
@@ -200,8 +200,10 @@ namespace BedrockLauncher.Handlers
                 Trace.WriteLine("Download start");
                 SetCancelation(true);
 
-                string dlPath = "Minecraft-" + v.Name + ".Appx";
-                if (!File.Exists(dlPath)) await DownloadPackage(v, dlPath, CancelSource);
+                string exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                string subDirectory = Path.Combine(exeDirectory, "Appx backups");
+                string dlPath = Path.Combine(subDirectory, "Minecraft-" + v.Name + ".Appx");
+                if (!File.Exists(Path.Combine(subDirectory, dlPath))) await DownloadPackage(v, dlPath, CancelSource);
                 await ExtractPackage(v, dlPath, CancelSource);
 
                 v.UpdateFolderSize();
@@ -299,6 +301,13 @@ namespace BedrockLauncher.Handlers
                 await File.WriteAllTextAsync(v.IdentificationPath, v.PackageID);
                 File.Delete(Path.Combine(v.GameDirectory, "AppxSignature.p7x"));
                 //File.Delete(dlPath);
+                string exeDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                string subDirectory = Path.Combine(exeDirectory, "Appx backups");
+                if (!Directory.Exists(subDirectory))
+                {
+                    Directory.CreateDirectory(subDirectory);
+                }
+                File.Move(Path.Combine(exeDirectory,dlPath),Path.Combine(subDirectory,dlPath));
 
                 Trace.WriteLine("Extracted successfully");
             }

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2024.8.14.5")]
+[assembly: AssemblyVersion("2024.8.14.12")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2024.8.14.12")]
+[assembly: AssemblyVersion("2024.8.14.15")]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
Code might be a bit sloppy, not that familiar with C#.

Now BedrockLauncher uses a subfolder to store & use .appx bundles instead of "app". I tested it and it seems to work reliably.