### PR TITLE
Fix for #505 - Not changing name of installation when editing crashing launcher

### DIFF
--- a/BedrockLauncher/Classes/BLProfileList.cs
+++ b/BedrockLauncher/Classes/BLProfileList.cs
@@ -419,7 +419,7 @@ namespace BedrockLauncher.Classes
                 Save();
             }
             //We need to move data to new directory
-            Directory.Move(Path.Combine(MainDataModel.Default.FilePaths.GetProfilePath(Properties.LauncherSettings.Default.CurrentProfileUUID), OldName), Path.Combine(MainDataModel.Default.FilePaths.GetProfilePath(Properties.LauncherSettings.Default.CurrentProfileUUID), name));
+            if (OldName != name) Directory.Move(Path.Combine(MainDataModel.Default.FilePaths.GetProfilePath(Properties.LauncherSettings.Default.CurrentProfileUUID), OldName), Path.Combine(MainDataModel.Default.FilePaths.GetProfilePath(Properties.LauncherSettings.Default.CurrentProfileUUID), name));
         }
         public void Installation_Delete(BLInstallation installation, bool deleteData = true)
         {

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2024.8.18.46")]
+[assembly: AssemblyVersion("2024.8.26.6")]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
Fixed issue #505 