### PR TITLE
Reverted a change

### DIFF
--- a/BedrockLauncher/Pages/Play/Home/PlayScreenPage.xaml
+++ b/BedrockLauncher/Pages/Play/Home/PlayScreenPage.xaml
@@ -127,7 +127,7 @@
         <Grid x:Name="PlayScreenBorder" Grid.Row="1" x:FieldModifier="public" VerticalAlignment="Bottom" Background="#FF262626">
             <TextBlock Style="{DynamicResource HeaderTextblock}" Text="{DynamicResource MainWindow_Disclaimer}" HorizontalAlignment="Right" Panel.ZIndex="0" VerticalAlignment="Center" Padding="0,0,5,0" Margin="0,0,0,0"/>
             <Button IsEnabled="{Binding Source={x:Static viewModels:MainDataModel.Default},Path=ProgressBarState.AllowPlaying, Mode=OneWay}" x:Name="MainPlayButton" Click="MainPlayButton_Click" HorizontalAlignment="Center" Margin="286,-8,286,0" VerticalAlignment="Top" Width="250" Height="56" Padding="0" Style="{DynamicResource BigGreenButton}">
-                <TextBlock x:Name="PlayButtonText" Style="{DynamicResource BigGreenButton_Text}" Text="{DynamicResource InstallationsPage_PlayButton}"/>
+                <TextBlock x:Name="PlayButtonText" Style="{DynamicResource BigGreenButton_Text}" Text="{Binding Source={x:Static viewModels:MainDataModel.Default}, Path=ProgressBarState.PlayButtonString, Mode=OneWay}"/>
             </Button>
             <controls:InstallationSelector x:Name="InstallationsList" 
                                            ItemsSource="{Binding Config.CurrentInstallations}" 

--- a/BedrockLauncher/Pages/Settings/General/Components/LanguageCombobox.xaml.cs
+++ b/BedrockLauncher/Pages/Settings/General/Components/LanguageCombobox.xaml.cs
@@ -1,4 +1,6 @@
-﻿using BedrockLauncher.Pages.Play.Home.Components;
+﻿using BedrockLauncher.Pages.Play.Home;
+using BedrockLauncher.Pages.Play.Home.Components;
+using BedrockLauncher.ViewModels;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -25,7 +27,6 @@ namespace BedrockLauncher.Pages.Settings.General.Components
             if (item == null) return;
             BedrockLauncher.Localization.Language.LanguageManager.SetLanguage(item.Locale);
             Program.OnApplicationRefresh();
-            
         }
 
 

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2024.9.8.30")]
+[assembly: AssemblyVersion("2024.9.8.58")]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
Had to revert a change as the button wasn't changing to "kill" when game is running. Big green button no longer updates on language change until game is ran.