### PR TITLE
Changes related to skipping WelcomePage4(Insider Account selection Screen)

### DIFF
--- a/BedrockLauncher/Pages/Welcome/WelcomePage.xaml.cs
+++ b/BedrockLauncher/Pages/Welcome/WelcomePage.xaml.cs
@@ -85,7 +85,7 @@ namespace BedrockLauncher.Pages.Welcome
                 {
                     Properties.LauncherSettings.Default.CurrentProfileUUID = MainDataModel.Default.Config.profiles.FirstOrDefault().Key;
                     Properties.LauncherSettings.Default.Save();
-                    MoveToPage(4);
+                    MoveToPage(5);
                 }
                 else
                 {

--- a/BedrockLauncher/Pages/Welcome/WelcomePageFive.xaml.cs
+++ b/BedrockLauncher/Pages/Welcome/WelcomePageFive.xaml.cs
@@ -12,6 +12,7 @@ namespace BedrockLauncher.Pages.Welcome
         public WelcomePageFive()
         {
             InitializeComponent();
+            BackButton.IsEnabled = false;
         }
 
         private void BackButton_Click(object sender, RoutedEventArgs e)

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2024.10.13.6")]
+[assembly: AssemblyVersion("2024.10.17.9")]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
1): if WelcomePage3(Profile Creation Screen) is skipped because of an existing profile the next page will now og to WelcomePage5(Final Page)

2): The 'Back' button in WelcomePage5 is now disabled 
*It was disabled in Page4