### PR TITLE
Fixes for #544 & #584

### DIFF
--- a/BedrockLauncher/Program.cs
+++ b/BedrockLauncher/Program.cs
@@ -53,6 +53,7 @@ namespace BedrockLauncher
                 LanguageManager.Init();
                 MainDataModel.Default.LoadConfig();
                 await MainDataModel.Default.LoadVersions(true);
+                MainDataModel.Default.ProgressBarState.PlayButtonLanguageChanged = !MainDataModel.Default.ProgressBarState.PlayButtonLanguageChanged;
                 if (await MainDataModel.Updater.CheckForUpdatesAsync(true)) MainViewModel.Default.UpdateButton.ShowUpdateButton();
                 Trace.WriteLine("Preparing Application: DONE");
             });

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2025.4.13.6")]
+[assembly: AssemblyVersion("2025.6.18.2")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2024.11.18.13")]
+[assembly: AssemblyVersion("2025.4.13.6")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/modules/Extensions.NET/ZipFileExtensions.cs
+++ b/modules/Extensions.NET/ZipFileExtensions.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.IO.Compression;
 using System.IO;
 using System.Threading;
+using System.Net;
 
 namespace JemExtensions
 {
@@ -55,12 +56,13 @@ namespace JemExtensions
                 if (cancelSource.IsCancellationRequested) throw new TaskCanceledException(nameof(source));
 
                 count++;
-                string fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, entry.FullName));
+                string decodedFullName = WebUtility.UrlDecode(entry.FullName);
+                string fileDestinationPath = Path.GetFullPath(Path.Combine(destinationDirectoryFullPath, decodedFullName));
 
                 if (!fileDestinationPath.StartsWith(destinationDirectoryFullPath, StringComparison.OrdinalIgnoreCase))
                     throw new IOException("File is extracting to outside of the folder specified.");
 
-                var zipProgress = new ZipProgress(source.Entries.Count, count, entry.FullName);
+                var zipProgress = new ZipProgress(source.Entries.Count, count, decodedFullName);
                 progress.Report(zipProgress);
 
                 if (Path.GetFileName(fileDestinationPath).Length == 0)


### PR DESCRIPTION
added a line of code to decode encoded path segments (%40/%20.etc) to fix the issue with some game files not maving the correct names.

added a line of code to switch the bool of PlayButtonLanguageChanged to update the Big green button play/kill text on app load.