### PR TITLE
Fixed installation combobox resetting selected installation on launcher refresh

### DIFF
--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2025.7.13.17")]
+[assembly: AssemblyVersion("2025.7.14.5")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/BedrockLauncher/ViewModels/MainDataModel.cs
+++ b/BedrockLauncher/ViewModels/MainDataModel.cs
@@ -59,7 +59,7 @@ namespace BedrockLauncher.ViewModels
         {
             Application.Current.Dispatcher.Invoke(() =>
             {
-                Config = BLProfileList.Load(FilePaths.GetProfilesFilePath(), Properties.LauncherSettings.Default.CurrentProfileUUID, Properties.LauncherSettings.Default.CurrentProfileUUID);
+                Config = BLProfileList.Load(FilePaths.GetProfilesFilePath(), Properties.LauncherSettings.Default.CurrentProfileUUID, Properties.LauncherSettings.Default.CurrentInstallationUUID);
             });
         }
         public async void KillGame() => await PackageManager.ClosePackage();


### PR DESCRIPTION
installation selection box now remembers the last selected profile on a launcher refresh or when the LoadConfig method is called.