### PR TITLE
Package launching backup

### DIFF
--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2025.6.20.4")]
+[assembly: AssemblyVersion("2025.6.22.8")]
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
When URI launch fails, Launcher attempts to launch package directly. 
Also fixes some issues with the progress bar when launching the game.