### PR TITLE
Appx download & extraction changes/fixes 

### DIFF
--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -21,6 +21,6 @@ using System.Windows;
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
-[assembly: AssemblyVersion("2025.7.23.15")]
+[assembly: AssemblyVersion("2025.7.23.21")]
 
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
Added code to switch the path to the appx package (AppxBackups/dlPath) in case an appx package exists in AppxBackups or need to be downloaded.
Added code to check if the extracting appx package is from AppxBackups to skip the keep appx logic.