### PR TITLE
Apply & Restart doesn't require admin privileges anymore.

### DIFF
--- a/BedrockLauncher/Pages/Settings/General/GeneralSettingsPage.xaml.cs
+++ b/BedrockLauncher/Pages/Settings/General/GeneralSettingsPage.xaml.cs
@@ -150,7 +150,7 @@ namespace BedrockLauncher.Pages.Settings.General
                 var startInfo = new ProcessStartInfo(path)
                 {
                     UseShellExecute = true,
-                    Verb = "runas"
+                    Verb = "open"
                 };
                 Process.Start(startInfo);
                 Application.Current.Shutdown();

--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2025.7.26.7")]
+[assembly: AssemblyVersion("2025.7.27.51")]
 
 
 [assembly: NeutralResourcesLanguage("en-US")]


### PR DESCRIPTION
replaced 'runas' with 'open' to start the launcher without elevated privileges