### PR TITLE
View crash report button now uses the correct path to the log file.

### DIFF
--- a/BedrockLauncher/Properties/AssemblyInfo.cs
+++ b/BedrockLauncher/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Windows;
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
 
 
-[assembly: AssemblyVersion("2025.7.27.58")]
+[assembly: AssemblyVersion("2025.7.29.6")]
 
 
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/BedrockLauncher/UI/Pages/Common/ErrorScreen.xaml.cs
+++ b/BedrockLauncher/UI/Pages/Common/ErrorScreen.xaml.cs
@@ -1,8 +1,11 @@
-﻿using System;
+﻿using BedrockLauncher.UI.Interfaces;
+using NLog;
+using NLog.Targets;
+using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using BedrockLauncher.UI.Interfaces;
 
 namespace BedrockLauncher.UI.Pages.Common
 {
@@ -32,7 +35,8 @@ namespace BedrockLauncher.UI.Pages.Common
 
         private void ErrorScreenViewCrashButton_Click(object sender, RoutedEventArgs e)
         {
-            System.Diagnostics.Process.Start("notepad.exe", $@"{Environment.CurrentDirectory}\Log.txt");
+            var logFileName = LogManager.Configuration.FindTargetByName<FileTarget>("allfile").FileName.Render(new LogEventInfo());
+            Process.Start("notepad.exe", logFileName);
         }
     }
     public static class ErrorScreenShow


### PR DESCRIPTION
-New behavior: Pressing the View crash report button now uses correct path to the log file.
-Old behavior:  Pressing the View crash report button would try to open 'log.txt' in the applications directory.
-Found the code on stackoverflow and simplified it a quite a bit.