### PR TITLE
Correct Some Spelling and Version Mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ---
 
-An unofficial **Minecraft for Windows 10** launcher that enables similar features from the **Minecraft Java Edition Launcher**.
+An unofficial **Minecraft Bedrock** launcher that enables similar features to the **Minecraft Java Edition Launcher**.
 
 [![Website](https://img.shields.io/github/v/tag/BedrockLauncher/BedrockLauncher.GitHub.io?color=blue&label=Visit%20Official%20Website&logo=github&style=for-the-badge)](https://bedrocklauncher.github.io/)
 [![Download Release](https://img.shields.io/github/v/release/BedrockLauncher/BedrockLauncher?label=Download%20Release&logo=windows&sort=date&style=for-the-badge)](https://github.com/BedrockLauncher/BedrockLauncher/releases/latest/)
@@ -22,7 +22,7 @@ Visit the official website to download the launcher
 - [Official website](https://bedrocklauncher.github.io)
 
 ## Compiling the launcher yourself
-You can compile the launcher yourself to prototype, iterate, or just enjoy the cutting edge build:
+You can compile the launcher yourself to prototype, iterate, or just enjoy the cutting-edge build:
 - [Compiling instructions](./docs/COMPILING.md)
 
 ## Screenshots


### PR DESCRIPTION
Updated the version on line 5 to "Minecraft Bedrock" because it says the old name, and some people might get confused when it says "Windows 10" and "Bedrock" as well. I also fixed some spelling mistakes (e.g., where it says "cutting edge," it's meant to be "cutting-edge") and changed "from" on line 5 to "to" because "similar from the" doesn't sound right compared to "similar to the".